### PR TITLE
Improve Python 2 & 3 compatiblity, declare it in setup.py

### DIFF
--- a/jcconv/jcconv.py
+++ b/jcconv/jcconv.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 __all__ = ['hira2kata', 'kata2hira', 'half2hira', 'hira2half', 'kata2half',
            'half2kata', 'half2wide', 'wide2half', 'convert',
@@ -87,7 +88,7 @@ def convert(text, frm, to, reserved=[]):
             text = _multiple_replace(text, conv_table)
         return uflag and text or text.encode('utf-8')
     else:
-        raise "Invalid Parameter"
+        raise ValueError("Invalid Parameter")
 
 def check(text, char_set_type):
     uflag = isinstance(text, text_type)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
+
 from setuptools import setup
+import codecs
 import os
 
-## Get long_description from index.txt:
-f = open(os.path.join('README.rst'))
-long_description = f.read().strip()
-f.close()
+with codecs.open(os.path.join('README.rst'), encoding='utf-8') as f:
+    long_description = f.read().strip()
 
 
 if __name__ == '__main__':
@@ -26,7 +27,14 @@ if __name__ == '__main__':
                         "Intended Audience :: Developers",
                         "License :: OSI Approved :: MIT License",
                         "Operating System :: POSIX",
-                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.5",
+                        "Programming Language :: Python :: 2.6",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
                         "Topic :: Software Development :: Libraries :: Python Modules"],
     tests_require = ['six'],
     test_suite = "jcconv.jcconv_test",


### PR DESCRIPTION
These are some additions for your taichino#6 PR, they:
- Ensure the README is properly decoded for `long_description` in Python 2.x
- Declare supported versions, for the benefit of https://python3wos.appspot.com/ etc.
- Correct a string exception, not supported in Python 3.x
- Allow a single wheel to serve all python versions
- Make print() behaviour consistent across all Python versions
